### PR TITLE
Fix glow color -1 handling

### DIFF
--- a/src/SDIHelper.cpp
+++ b/src/SDIHelper.cpp
@@ -305,9 +305,20 @@ bool SDIHelper::getGlow(bool isP2) {
 }
 
 int SDIHelper::getGlowColor(bool isP2) {
-    return m_isP2Main != isP2
-        ? SDI_GET_VALUE(int64_t, "colorglow", 0)
-        : GameManager::get()->getPlayerGlowColor();
+    if (m_isP2Main != isP2) {
+        int64_t colorglow = SDI_GET_VALUE(int64_t, "colorglow", 0);
+        // vanilla behavior when glow color is -1
+        if (colorglow == -1) {
+            return SDI_GET_VALUE(int64_t, "color2", 0);
+        }
+        return colorglow;
+    } else {
+        int colorglow = GameManager::get()->getPlayerGlowColor();
+        if (colorglow == -1) {
+            return GameManager::get()->getPlayerColor2();
+        }
+        return colorglow;
+    }
 }
 
 void SDIHelper::logAll() {

--- a/src/hooks/CharacterColorPage.cpp
+++ b/src/hooks/CharacterColorPage.cpp
@@ -107,6 +107,7 @@ class $modify(MyCharacterColorPage, CharacterColorPage) {
             auto color1 = SDI_GET_VALUE(int64_t, "color1", 0);
             auto color2 = SDI_GET_VALUE(int64_t, "color2", 0);
             auto colorglow = SDI_GET_VALUE(int64_t, "colorglow", 0);
+            if (colorglow == -1) colorglow = color2;
 
             for (auto [i, sprite] : CCDictionaryExt<intptr_t, ColorChannelSprite*>(m_colorButtons)) {
                 if (i == color1) {
@@ -186,8 +187,13 @@ class $modify(MyCharacterColorPage, CharacterColorPage) {
             auto GM = GameManager::get();
             for (auto* icon : CCArrayExt<SimplePlayer*>(m_playerObjects)) {
                 icon->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
-                icon->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-                icon->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+                int color2 = SDI_GET_VALUE(int64_t, "color2", 0);
+                int colorglow = SDI_GET_VALUE(int64_t, "colorglow", 0);
+                icon->setSecondColor(GM->colorForIdx(color2));
+                if (colorglow == -1)
+                  icon->enableCustomGlowColor(GM->colorForIdx(color2));
+                else 
+                  icon->enableCustomGlowColor(GM->colorForIdx(colorglow));
                 icon->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
                 icon->updateColors();
             }

--- a/src/hooks/GJGarageLayer.cpp
+++ b/src/hooks/GJGarageLayer.cpp
@@ -268,8 +268,10 @@ class $modify(MyGarageLayer, GJGarageLayer) {
                 break;
         }
         m_playerObject->setColor(GM->colorForIdx(GM->m_playerColor));
-        m_playerObject->setSecondColor(GM->colorForIdx(GM->m_playerColor2));
-        m_playerObject->enableCustomGlowColor(GM->colorForIdx(GM->m_playerGlowColor));
+        int col2idx = GM->m_playerGlowColor;
+        int glowidx = GM->m_playerGlowColor;
+        m_playerObject->setSecondColor(GM->colorForIdx(col2idx));
+        m_playerObject->enableCustomGlowColor(GM->colorForIdx((glowidx == -1) ? col2idx : glowidx));
         m_playerObject->m_hasGlowOutline = GM->m_playerGlow;
         m_playerObject->updateColors();
 
@@ -303,8 +305,10 @@ class $modify(MyGarageLayer, GJGarageLayer) {
                 break;
         }
         m_fields->player2->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
-        m_fields->player2->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-        m_fields->player2->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+        col2idx = SDI_GET_VALUE(int64_t, "color2", 0);
+        glowidx = SDI_GET_VALUE(int64_t, "colorglow", 0);
+        m_fields->player2->setSecondColor(GM->colorForIdx(col2idx));
+        m_fields->player2->enableCustomGlowColor(GM->colorForIdx((glowidx == -1) ? col2idx : glowidx));
         m_fields->player2->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
         m_fields->player2->updateColors();
     }
@@ -382,8 +386,10 @@ class $modify(MyGarageLayer, GJGarageLayer) {
         m_fields->player2->setPositionX(m_fields->player2->getPositionX() + winSize.width/6);
 
         m_fields->player2->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
-        m_fields->player2->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-        m_fields->player2->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+        int col2idx = SDI_GET_VALUE(int64_t, "color2", 0);
+        int glowidx = SDI_GET_VALUE(int64_t, "colorglow", 0);
+        m_fields->player2->setSecondColor(GM->colorForIdx(col2idx));
+        m_fields->player2->enableCustomGlowColor(GM->colorForIdx((glowidx == -1) ? col2idx : glowidx));
         m_fields->player2->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
         m_fields->player2->updateColors();
 
@@ -753,8 +759,10 @@ class $modify(MyGarageLayer, GJGarageLayer) {
         if (SDI_GET_VALUE(bool, "2pselected", false)) {
             auto GM = GameManager::get();
             m_fields->player2->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
-            m_fields->player2->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            m_fields->player2->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            int col2idx = SDI_GET_VALUE(int64_t, "color2", 0);
+            int glowidx = SDI_GET_VALUE(int64_t, "colorglow", 0);
+            m_fields->player2->setSecondColor(GM->colorForIdx(col2idx));
+            m_fields->player2->enableCustomGlowColor(GM->colorForIdx((glowidx == -1) ? col2idx : glowidx));
             m_fields->player2->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             m_fields->player2->updateColors();
         }

--- a/src/hooks/ProfilePage.cpp
+++ b/src/hooks/ProfilePage.cpp
@@ -10,11 +10,6 @@ class $modify(MyProfilePage, ProfilePage) {
         bool hasLoaded = false;
     };
 
-    static void onModify(auto& self) {
-        Result<> result = self.setHookPriorityBefore("ProfilePage::loadPageFromUserInfo", "rynat.better_unlock_info");
-        if (!result && *result.err() != "Mod not found") log::error("Failed to set hook priority. Glow colors may break on the jetpack with Better Unlock Info.");
-    }
-
     void toggleShip(CCObject* sender) {
         ProfilePage::toggleShip(sender);
 
@@ -65,7 +60,7 @@ class $modify(MyProfilePage, ProfilePage) {
         if (static_cast<CCMenuItemToggler*>(sender)->isOn()) {
             SDI_SET_VALUE(bool, "2pselected", false);
             int glowidx = GM->getPlayerGlowColor();
-            if (glowidx == -1) glowidx = GM->getPlayerColor2();
+            if (glowidx == -1) glowidx = 0;
 
             cube->updatePlayerFrame(GM->getPlayerFrame(), IconType::Cube);
             cube->setColor(GM->colorForIdx(GM->getPlayerColor()));
@@ -138,7 +133,7 @@ class $modify(MyProfilePage, ProfilePage) {
         } else {
             SDI_SET_VALUE(bool, "2pselected", true);
             int glowidx = SDI_GET_VALUE(int64_t, "colorglow", 0);
-            if (glowidx == -1) glowidx = SDI_GET_VALUE(int64_t, "color2", 0);
+            if (glowidx == -1) glowidx = 0;
 
             cube->updatePlayerFrame(SDI_GET_VALUE(int64_t, "cube", 1), IconType::Cube);
             cube->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
@@ -232,7 +227,7 @@ class $modify(MyProfilePage, ProfilePage) {
         if (this->m_ownProfile) {
             if (auto menu = m_mainLayer->getChildByID("player-menu")) {
                 int glowidx = GM->getPlayerGlowColor();
-                if (glowidx == -1) glowidx = GM->getPlayerColor2();
+                if (glowidx == -1) glowidx = 0;
 
                 if (auto player = getPlayer(menu->getChildByID("player-icon"))) {
                     player->updatePlayerFrame(GM->getPlayerFrame(), IconType::Cube);
@@ -304,16 +299,6 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
-                }
-                // BUI added
-                auto jetpack = menu->getChildByID("player-jetpack") ? getPlayer(menu->getChildByID("player-jetpack")) : nullptr;
-                if (jetpack) {
-                    jetpack->updatePlayerFrame(GM->getPlayerJetpack(), IconType::Jetpack);
-                    jetpack->setColor(GM->colorForIdx(GM->getPlayerColor()));
-                    jetpack->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    jetpack->enableCustomGlowColor(GM->colorForIdx(glowidx));
-                    jetpack->m_hasGlowOutline = GM->getPlayerGlow();
-                    jetpack->updateColors();
                 }
             }
         }

--- a/src/hooks/ProfilePage.cpp
+++ b/src/hooks/ProfilePage.cpp
@@ -59,11 +59,13 @@ class $modify(MyProfilePage, ProfilePage) {
 
         if (static_cast<CCMenuItemToggler*>(sender)->isOn()) {
             SDI_SET_VALUE(bool, "2pselected", false);
+            int glowidx = GM->getPlayerGlowColor();
+            if (glowidx == -1) glowidx = GM->getPlayerColor2();
 
             cube->updatePlayerFrame(GM->getPlayerFrame(), IconType::Cube);
             cube->setColor(GM->colorForIdx(GM->getPlayerColor()));
             cube->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            cube->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            cube->enableCustomGlowColor(GM->colorForIdx(glowidx));
             cube->m_hasGlowOutline = GM->getPlayerGlow();
             cube->updateColors();
 
@@ -74,7 +76,7 @@ class $modify(MyProfilePage, ProfilePage) {
 
                 jetpack->setColor(GM->colorForIdx(GM->getPlayerColor()));
                 jetpack->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                jetpack->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                jetpack->enableCustomGlowColor(GM->colorForIdx(glowidx));
                 jetpack->m_hasGlowOutline = GM->getPlayerGlow();
                 jetpack->updateColors();
             } else {
@@ -83,58 +85,60 @@ class $modify(MyProfilePage, ProfilePage) {
             }
             ship->setColor(GM->colorForIdx(GM->getPlayerColor()));
             ship->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            ship->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            ship->enableCustomGlowColor(GM->colorForIdx(glowidx));
             ship->m_hasGlowOutline = GM->getPlayerGlow();
             ship->updateColors();
 
             ball->updatePlayerFrame(GM->getPlayerBall(), IconType::Ball);
             ball->setColor(GM->colorForIdx(GM->getPlayerColor()));
             ball->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            ball->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            ball->enableCustomGlowColor(GM->colorForIdx(glowidx));
             ball->m_hasGlowOutline = GM->getPlayerGlow();
             ball->updateColors();
 
             ufo->updatePlayerFrame(GM->getPlayerBird(), IconType::Ufo);
             ufo->setColor(GM->colorForIdx(GM->getPlayerColor()));
             ufo->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            ufo->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            ufo->enableCustomGlowColor(GM->colorForIdx(glowidx));
             ufo->m_hasGlowOutline = GM->getPlayerGlow();
             ufo->updateColors();
 
             wave->updatePlayerFrame(GM->getPlayerDart(), IconType::Wave);
             wave->setColor(GM->colorForIdx(GM->getPlayerColor()));
             wave->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            wave->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            wave->enableCustomGlowColor(GM->colorForIdx(glowidx));
             wave->m_hasGlowOutline = GM->getPlayerGlow();
             wave->updateColors();
 
             robot->updatePlayerFrame(GM->getPlayerRobot(), IconType::Robot);
             robot->setColor(GM->colorForIdx(GM->getPlayerColor()));
             robot->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            robot->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            robot->enableCustomGlowColor(GM->colorForIdx(glowidx));
             robot->m_hasGlowOutline = GM->getPlayerGlow();
             robot->updateColors();
 
             spider->updatePlayerFrame(GM->getPlayerSpider(), IconType::Spider);
             spider->setColor(GM->colorForIdx(GM->getPlayerColor()));
             spider->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            spider->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            spider->enableCustomGlowColor(GM->colorForIdx(glowidx));
             spider->m_hasGlowOutline = GM->getPlayerGlow();
             spider->updateColors();
 
             swing->updatePlayerFrame(GM->getPlayerSwing(), IconType::Swing);
             swing->setColor(GM->colorForIdx(GM->getPlayerColor()));
             swing->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-            swing->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+            swing->enableCustomGlowColor(GM->colorForIdx(glowidx));
             swing->m_hasGlowOutline = GM->getPlayerGlow();
             swing->updateColors();
         } else {
             SDI_SET_VALUE(bool, "2pselected", true);
+            int glowidx = SDI_GET_VALUE(int64_t, "colorglow", 0);
+            if (glowidx == -1) glowidx = SDI_GET_VALUE(int64_t, "color2", 0);
 
             cube->updatePlayerFrame(SDI_GET_VALUE(int64_t, "cube", 1), IconType::Cube);
             cube->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             cube->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            cube->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            cube->enableCustomGlowColor(GM->colorForIdx(glowidx));
             cube->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             cube->updateColors();
 
@@ -145,7 +149,7 @@ class $modify(MyProfilePage, ProfilePage) {
 
                 jetpack->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
                 jetpack->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-                jetpack->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+                jetpack->enableCustomGlowColor(GM->colorForIdx(glowidx));
                 jetpack->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
                 jetpack->updateColors();
             } else {
@@ -154,7 +158,7 @@ class $modify(MyProfilePage, ProfilePage) {
             }
             ship->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             ship->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            ship->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            ship->enableCustomGlowColor(GM->colorForIdx(glowidx));
             ship->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             ship->updateColors();
             //
@@ -162,42 +166,42 @@ class $modify(MyProfilePage, ProfilePage) {
             ball->updatePlayerFrame(SDI_GET_VALUE(int64_t, "roll", 1), IconType::Ball);
             ball->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             ball->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            ball->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            ball->enableCustomGlowColor(GM->colorForIdx(glowidx));
             ball->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             ball->updateColors();
 
             ufo->updatePlayerFrame(SDI_GET_VALUE(int64_t, "bird", 1), IconType::Ufo);
             ufo->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             ufo->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            ufo->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            ufo->enableCustomGlowColor(GM->colorForIdx(glowidx));
             ufo->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             ufo->updateColors();
 
             wave->updatePlayerFrame(SDI_GET_VALUE(int64_t, "dart", 1), IconType::Wave);
             wave->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             wave->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            wave->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            wave->enableCustomGlowColor(GM->colorForIdx(glowidx));
             wave->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             wave->updateColors();
 
             robot->updatePlayerFrame(SDI_GET_VALUE(int64_t, "robot", 1), IconType::Robot);
             robot->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             robot->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            robot->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            robot->enableCustomGlowColor(GM->colorForIdx(glowidx));
             robot->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             robot->updateColors();
 
             spider->updatePlayerFrame(SDI_GET_VALUE(int64_t, "spider", 1), IconType::Spider);
             spider->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             spider->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            spider->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            spider->enableCustomGlowColor(GM->colorForIdx(glowidx));
             spider->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             spider->updateColors();
 
             swing->updatePlayerFrame(SDI_GET_VALUE(int64_t, "swing", 1), IconType::Swing);
             swing->setColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color1", 0)));
             swing->setSecondColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "color2", 0)));
-            swing->enableCustomGlowColor(GM->colorForIdx(SDI_GET_VALUE(int64_t, "colorglow", 0)));
+            swing->enableCustomGlowColor(GM->colorForIdx(glowidx));
             swing->m_hasGlowOutline = SDI_GET_VALUE(bool, "glow", false);
             swing->updateColors();
         }
@@ -222,11 +226,14 @@ class $modify(MyProfilePage, ProfilePage) {
 
         if (this->m_ownProfile) {
             if (auto menu = m_mainLayer->getChildByID("player-menu")) {
+                int glowidx = GM->getPlayerGlowColor();
+                if (glowidx == -1) glowidx = GM->getPlayerColor2();
+
                 if (auto player = getPlayer(menu->getChildByID("player-icon"))) {
                     player->updatePlayerFrame(GM->getPlayerFrame(), IconType::Cube);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -235,7 +242,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerShip(), IconType::Ship);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -244,7 +251,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerBall(), IconType::Ball);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -253,7 +260,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerBird(), IconType::Ufo);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -262,7 +269,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerDart(), IconType::Wave);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -271,7 +278,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerRobot(), IconType::Robot);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -280,7 +287,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerSpider(), IconType::Spider);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }
@@ -289,7 +296,7 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->updatePlayerFrame(GM->getPlayerSwing(), IconType::Swing);
                     player->setColor(GM->colorForIdx(GM->getPlayerColor()));
                     player->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
-                    player->enableCustomGlowColor(GM->colorForIdx(GM->getPlayerGlowColor()));
+                    player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
                 }

--- a/src/hooks/ProfilePage.cpp
+++ b/src/hooks/ProfilePage.cpp
@@ -10,6 +10,11 @@ class $modify(MyProfilePage, ProfilePage) {
         bool hasLoaded = false;
     };
 
+    static void onModify(auto& self) {
+        Result<> result = self.setHookPriorityBefore("ProfilePage::loadPageFromUserInfo", "rynat.better_unlock_info");
+        if (!result && *result.err() != "Mod not found") log::error("Failed to set hook priority. Glow colors may break on the jetpack with Better Unlock Info.");
+    }
+
     void toggleShip(CCObject* sender) {
         ProfilePage::toggleShip(sender);
 
@@ -299,6 +304,16 @@ class $modify(MyProfilePage, ProfilePage) {
                     player->enableCustomGlowColor(GM->colorForIdx(glowidx));
                     player->m_hasGlowOutline = GM->getPlayerGlow();
                     player->updateColors();
+                }
+                // BUI added
+                auto jetpack = menu->getChildByID("player-jetpack") ? getPlayer(menu->getChildByID("player-jetpack")) : nullptr;
+                if (jetpack) {
+                    jetpack->updatePlayerFrame(GM->getPlayerJetpack(), IconType::Jetpack);
+                    jetpack->setColor(GM->colorForIdx(GM->getPlayerColor()));
+                    jetpack->setSecondColor(GM->colorForIdx(GM->getPlayerColor2()));
+                    jetpack->enableCustomGlowColor(GM->colorForIdx(glowidx));
+                    jetpack->m_hasGlowOutline = GM->getPlayerGlow();
+                    jetpack->updateColors();
                 }
             }
         }


### PR DESCRIPTION
If the player's glow color is -1, the vanilla game copies the 2nd player color. This typically allows you to achieve the following effect without having SDI at all (notice the glow colors are different because the player colors are swapped):
<img width="1079" height="955" alt="image" src="https://github.com/user-attachments/assets/348da288-114d-4546-a2d0-bd6d19504320" />

SDI completely breaks this vanilla behavior and makes those glow colors white, both in-game and in the icon kit color selection page.

This PR fixes the behavior. It is technically unnecessary because whatever could be achieved using -1 glow color can be achieved using SDI on its own, by setting the colors manually, so you can merge at your discretion. I just wanted to make it consistent with vanilla behavior.